### PR TITLE
正确地显示用户链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ PRs are very welcomed.
 
 Don't want to code? Open an issue then.
 
-We can also be reached at TG @wikipedia\_zh
+We can also be reached at TG @wikipedia\_zh\_n

--- a/StaphMbot.py
+++ b/StaphMbot.py
@@ -91,7 +91,7 @@ class tgapi:
                 time.sleep(delay)
         misc['text'] = text
         misc['chat_id'] = target
-        misc['parse_mode'] = 'MarkdownV2'
+        misc['parse_mode'] = 'HTML'
         try:
             data = self.query('sendMessage',misc,retry=0)
         except APIError:
@@ -236,7 +236,7 @@ def getNameRep(userObj):
     else:
         name = userObj['first_name']
     if 'id' in userObj:
-        return '['+name+']('+'tg://user?id='+str(userObj['id'])+')'
+        return '<a href="tg://user?id='+str(userObj['id'])+">'+name+'</a>'
     else:
         return '@'+name
 

--- a/StaphMbot.py
+++ b/StaphMbot.py
@@ -91,6 +91,7 @@ class tgapi:
                 time.sleep(delay)
         misc['text'] = text
         misc['chat_id'] = target
+        misc['parse_mode'] = 'MarkdownV2'
         try:
             data = self.query('sendMessage',misc,retry=0)
         except APIError:
@@ -227,12 +228,17 @@ def getName(uid,gid,api,lookup={}):
     return getNameRep(result['user'])
 
 def getNameRep(userObj):
+    name = ''
     if 'username' in userObj:
-        return '@'+userObj['username']
+        name = userObj['username']
     elif 'last_name' in userObj:
-        return '@'+userObj['first_name']+' '+userObj['last_name']
+        name = userObj['first_name']+' '+userObj['last_name']
     else:
-        return '@'+userObj['first_name']
+        name = userObj['first_name']
+    if 'id' in userObj:
+        return '['+name+']('+'tg://user?id='+str(userObj['id'])+')'
+    else:
+        return '@'+name
 
 def getMsgText(msgObj):
     return msgObj['text'] if 'text' in msgObj else '<Multimedia Message>'


### PR DESCRIPTION
userObj 有提供 id 时，使用 tg://user?id=<user_id> 的链接，可以保证即使目标没有 username，也能指向正确的用户。
由于发送链接需要指定 parse_mode，我在 tgapi 的 sendMessage 中指定了默认的 parse_mode 为 `MarkdownV2`。参考 [tg 官方文档](https://core.telegram.org/bots/api#formatting-options)。我简单看了下这个变更不会影响机器人发送的其他消息，不过还请再复核一下。
另外，顺手更新了 readme 里主群的链接。